### PR TITLE
Remove ability to abort in BOOTING and BOOTED

### DIFF
--- a/Piper/Piper_PackML.c
+++ b/Piper/Piper_PackML.c
@@ -51,19 +51,7 @@ plcbit Piper_PackML(struct Piper_typ* Piper)
 				PiperStateChange(Piper,MACH_ST_BOOTED);
 			
 			}
-		
-			/****************************/
-			/* Check for machine CMDs	*/
-			/****************************/
-		
-			if( Piper->IN.CMD.Abort ){
-
-				logInfo(Piper->IN.CFG.LoggerName,0,"Command Abort",0);
 			
-				PiperStateChange(Piper,MACH_ST_ABORTING);
-			
-			}
-		
 			break;
 		
 		case MACH_ST_BOOTED:
@@ -78,17 +66,7 @@ plcbit Piper_PackML(struct Piper_typ* Piper)
 				
 				PiperStateChange(Piper,MACH_ST_STOPPED);
 			
-			}
-		
-			/****************************/
-			/* Check for machine CMDs	*/
-			/****************************/
-		
-			if( Piper->IN.CMD.Abort ){
-  				
-				logInfo(Piper->IN.CFG.LoggerName,0,"Abort Command",0);
-			
-				PiperStateChange(Piper,MACH_ST_ABORTING);		
+
 		
 			}
 		


### PR DESCRIPTION
This doesn't really makes sense and can cause issues if the machine assumes you have completed booting for getting into normal machine states. 