### PR TITLE
Expand stringext dependency to support v0.15.x

### DIFF
--- a/src/Ar/Piper/ANSIC.lby
+++ b/src/Ar/Piper/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<?AutomationStudio Version=4.5.5.113 SP?>
-<Library Version="0.01.9" SubType="ANSIC" Description="A new source library" xmlns="http://br-automation.co.at/AS/Library">
+<?AutomationStudio FileVersion="4.9"?>
+<Library Version="0.02.0" SubType="ANSIC" Description="A new source library" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">Piper.typ</File>
     <File Description="Exported constants">Piper.var</File>
@@ -21,6 +21,6 @@
     <Dependency ObjectName="LogThat" FromVersion="0.05.0" ToVersion="0.05.9" />
     <Dependency ObjectName="sys_lib" />
     <Dependency ObjectName="AsBrStr" />
-    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.14.9" />
+    <Dependency ObjectName="StringExt" FromVersion="0.14.0" ToVersion="0.15.9" />
   </Dependencies>
 </Library>

--- a/src/Ar/Piper/CHANGELOG.md
+++ b/src/Ar/Piper/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change log
+0.2.0 - Expand stringext dependency
 
 0.1.9 - Add Piper_getBusyModules to display several busy modules at once
       - Prevent abort commands while in BOOTING and BOOTED


### PR DESCRIPTION
Expand StringExt dependency to support v0.15.x

StringExt v0.15.x is backwards-compatible with v0.14.x and should be allowed

We can't do vX.XX.10 so this has to be a minor version bump...
